### PR TITLE
Corrige informação da escola na página de cidades

### DIFF
--- a/components/TabelaMapaCapital.vue
+++ b/components/TabelaMapaCapital.vue
@@ -150,7 +150,7 @@ let bases = computed(()=>{return capital.value?Object.values(capital.value.entra
             </div>
             <div class="text-center">
               <div class="bg-rosaClaro p-1 mb-1 rounded">baixo</div>
-              <div>1 - 40</div>
+              <div>21 - 40</div>
             </div>
             <div class="text-center">
               <div class="bg-bege p-1 mb-1 rounded">médio</div>


### PR DESCRIPTION
## Evidências 
Antes: a categoria `abaixo` estava com intervalo de 1 - 40
![image](https://github.com/okfn-brasil/indice-dados-abertos/assets/44185775/a6f32365-e032-4533-b315-1d454853851c)

Depois: versão corrigida 
![image](https://github.com/okfn-brasil/indice-dados-abertos/assets/44185775/582433c0-557d-4f76-946e-2f288596731c)
